### PR TITLE
Display errors in native notification daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ General (mpv) player options should be set (usually) in
 `--no-terminal` should be put in `OPTS` variable and
 separated with space ie: `--no-terminal --screen 1`.
 
+### Receive native notifications on errors
+
+Modify `ytdl_config.py` to set the `NOTIFY_COMMAND` to a command, such as
+`notify-send` on Linux to provide native notifications when a video cannot be
+found.
+
 ## How does it work
 
 Whenever 'Play with mpv' is selected in browser,

--- a/ytdl_config.py
+++ b/ytdl_config.py
@@ -2,3 +2,4 @@ HOST = '127.0.0.1'
 PORT = 9000
 PLAYER = 'mpv'
 OPTS = '--no-terminal'
+NOTIFY_COMMAND = 'notify-send'

--- a/ytdl_server.py
+++ b/ytdl_server.py
@@ -11,11 +11,13 @@ if sys.version_info.major == 2:
     from SimpleHTTPServer import SimpleHTTPRequestHandler as RequestHandler
     import SocketServer
     import urlparse as parse
+    from distutils.spawn import find_executable as which
 else:
     from http.server import HTTPServer
     from http.server import SimpleHTTPRequestHandler as RequestHandler
     import socketserver as SocketServer
     from urllib import parse
+    from shutil import which
 
 # Check https://github.com/rg3/youtube-dl/
 import youtube_dl
@@ -36,9 +38,11 @@ y = youtube_dl.YoutubeDL({
 
 def report_error(summary, message=""):
     print(summary + ': ' + message)
-    # TODO what if the command doesn't exist?
-    if not ytdl_config.NOTIFY_COMMAND == '':
+    # http://stackoverflow.com/a/12611523/2257038
+    if not ytdl_config.NOTIFY_COMMAND == '' and which(ytdl_config.NOTIFY_COMMAND):
         subprocess.Popen([ytdl_config.NOTIFY_COMMAND, "YoutubeDL mpv: " + summary, message])
+    else:
+        print("Error: NOTIFY_COMMAND is unset, or does not exist")
 
 class MyHandler(RequestHandler):
     """

--- a/ytdl_server.py
+++ b/ytdl_server.py
@@ -34,6 +34,11 @@ y = youtube_dl.YoutubeDL({
     'forcejson': True
     })
 
+def report_error(summary, message=""):
+    print(summary + ': ' + message)
+    # TODO what if the command doesn't exist?
+    if not ytdl_config.NOTIFY_COMMAND == '':
+        subprocess.Popen([ytdl_config.NOTIFY_COMMAND, "YoutubeDL mpv: " + summary, message])
 
 class MyHandler(RequestHandler):
     """
@@ -59,6 +64,7 @@ class MyHandler(RequestHandler):
 
         data = self.match_id(yt_url)
         if not data:
+            report_error("No file found", "No file found for " + yt_url)
             return self.send_response(400)
 
         video_url = ''
@@ -77,7 +83,7 @@ class MyHandler(RequestHandler):
 
             if video_url_hi == '':
                 if video_url_lo == '':
-                    print('Unknown format. Cannot play video from:', yt_url)
+                    report_error('Unknown format', 'Cannot play video from' + yt_url)
                     return self.send_response(400)
                 video_url = video_url_lo
             else:


### PR DESCRIPTION
When we have an error, display it using a native notification tool.
This makes it easier for the user to determine when a page is loading,
and when it just isn't able to parse the page.

By default, use Linux's `notify-send`.
