### PR TITLE
Add support for YouTube URL's with a specific time

### DIFF
--- a/ytdl_server.py
+++ b/ytdl_server.py
@@ -79,6 +79,7 @@ class MyHandler(RequestHandler):
             # youtube video
             video_url_lo = ''
             video_url_hi = ''
+            start_time = 0
             for format_id in data['formats']:
                 if 'format_id' in format_id and format_id['format_id'] == '22':
                     video_url_hi = format_id['url']
@@ -92,12 +93,18 @@ class MyHandler(RequestHandler):
                 video_url = video_url_lo
             else:
                 video_url = video_url_hi
+            if 'start_time' in data and data['start_time'] is not None:
+                start_time = int(float(data['start_time']))
 
         # Get additional options
         command = list(map(str, ytdl_config.OPTS.split(' ')))
 
         # Prepend default player
         command.insert(0, ytdl_config.PLAYER)
+        
+        # Append start time option
+        if start_time and start_time != 0:
+            command.append('--start=+' + str(start_time))
 
         # Append video url
         command.append(video_url)


### PR DESCRIPTION
Adds an extra variable to catch the 'start_time' data after the 'youtube_dl' module extracts the info. It returns a float of how many seconds in the video should start from which is converted into an int for simplicities sake. If there was a 'start_time' it will append the MPV option "--start=+" plus whatever the number of seconds is. I can only test this on my computer so some testing may be necessary. Also Python's not my main language so I apologize if it's messy or wrong, if so feel free to give me tips or just rewrite it.
