### PR TITLE
Fix a bug regarding non-youtube videos

### DIFF
--- a/ytdl_server.py
+++ b/ytdl_server.py
@@ -75,6 +75,7 @@ class MyHandler(RequestHandler):
         if 'url' in data:
             # Non-youtube video?
             video_url = data['url']
+            start_time = 0
         else:
             # youtube video
             video_url_lo = ''
@@ -101,7 +102,7 @@ class MyHandler(RequestHandler):
 
         # Prepend default player
         command.insert(0, ytdl_config.PLAYER)
-        
+
         # Append start time option
         if start_time and start_time != 0:
             command.append('--start=+' + str(start_time))


### PR DESCRIPTION
Hi there,

I've found a bug regrading playing non-youtube videos.

The code does not set `start_time` when playing non-youtube videos, and it would cause an error due to that:

```
Exception happened during processing of request from ('127.0.0.1', 51464)
Traceback (most recent call last):
  File "/usr/lib/python3.5/socketserver.py", line 625, in process_request_thread
    self.finish_request(request, client_address)
  File "/usr/lib/python3.5/socketserver.py", line 354, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/lib/python3.5/socketserver.py", line 681, in __init__
    self.handle()
  File "/usr/lib/python3.5/http/server.py", line 422, in handle
    self.handle_one_request()
  File "/usr/lib/python3.5/http/server.py", line 410, in handle_one_request
    method()
  File "ytdl_server.py", line 106, in do_GET
    if start_time and start_time != 0:
UnboundLocalError: local variable 'start_time' referenced before assignment

```

Fixed by setting `start_time` to 0 whenever non-youtube video is being played
